### PR TITLE
fix: avoid alternate screen in searchable prompt (fixes Windows terminal close)

### DIFF
--- a/src/cli/__tests__/prompts.test.ts
+++ b/src/cli/__tests__/prompts.test.ts
@@ -132,14 +132,14 @@ describe('ChoicePrompt', () => {
       // Verify raw mode was set
       expect(mockStdin.setRawMode).toHaveBeenCalledWith(true);
 
-      // Verify alternate screen buffer was activated
-      expect(mockStdout.write).toHaveBeenCalledWith('\x1B[?1049h');
+      // In-place mode: cursor hidden only, no alternate screen (1049h/1049l)
       expect(mockStdout.write).toHaveBeenCalledWith('\x1B[?25l');
 
       expect(result).toEqual({ id: '1', label: 'Option 1' });
-      // Verify cleanup
+      // Verify cleanup: cursor restored only (no 1049l)
       expect(mockStdout.write).toHaveBeenCalledWith('\x1B[?25h');
-      expect(mockStdout.write).toHaveBeenCalledWith('\x1B[?1049l');
+      expect(mockStdout.write).not.toHaveBeenCalledWith('\x1B[?1049h');
+      expect(mockStdout.write).not.toHaveBeenCalledWith('\x1B[?1049l');
     });
 
     it('should handle arrow key navigation', async () => {


### PR DESCRIPTION
## Summary
Fixes the bug where the terminal would close when reaching the second interactive selection (workflow `choose`/`prompt`) on Windows after `tp run`.

## Cause
The searchable choice menu used the alternate screen buffer (ANSI `1049h`/`1049l`). On Windows, using this buffer on the second prompt (after the first workflow file selection) could cause the terminal to exit or crash.

## Change
- **Single implementation**: Replaced the alternate-screen searchable prompt with an in-place redraw implementation.
- **Tests**: Updated `prompts.test.ts` to assert that `1049h`/`1049l` are never called.

